### PR TITLE
feat: Set default sort order to descending for created_at in LogsTable

### DIFF
--- a/src/components/LogsTable.js
+++ b/src/components/LogsTable.js
@@ -181,6 +181,7 @@ const LogsTable = () => {
             dataIndex: 'created_at',
             render: renderTimestamp,
             sorter: (a, b) => a.created_at - b.created_at,
+            defaultSortOrder: 'descend',
         },
         {
             title: '令牌名称',


### PR DESCRIPTION
默认使用时间降序来保持与new-api显示的一致性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Logs table now defaults to displaying the most recent entries first, improving visibility into recent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->